### PR TITLE
add error param obtained from queryParam when dispatch redirect event

### DIFF
--- a/src/components/Pwall.vue
+++ b/src/components/Pwall.vue
@@ -28,7 +28,8 @@ export default {
               new CustomEvent('payment_wall_process_redirect', {
                 detail: {
                   request_id: vm.$route.query.request_id || vm.$route.query.reference_id,
-                  method: vm.$route.query.method
+                  method: vm.$route.query.method,
+                  error: vm.$route.query.error || null
                   }
                 })
             );


### PR DESCRIPTION
Comparing this implementation with a plain .html file example for the integration:
![image](https://user-images.githubusercontent.com/12449936/69332388-e102cf80-0c56-11ea-95e7-2d29ab47f57e.png)

 It looks like the **error** param is missing on this vue implementation when the `payment_wall_process_redirect` event is triggered